### PR TITLE
V0.3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ htmlcov/
 .coverage
 .pytest_cache/
 trash-compactor.spec
+trash-compactor-user.spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2025-10-08
+### Added
+- `-s/--single-worker` flag (and interactive toggle) to run compression sequentially when fragile storage needs a gentler touch
+- HDD safeguard now offers an opt-in prompt to downgrade to single-worker mode and honours manual overrides automatically
+
+### Changed
+- Volume detection inspects only the target drive, blocks remote or non-NTFS paths up front, and logs flash controllers that omit seek-penalty hints
+- Compression and branding worker pools respect the new runtime worker cap, with user-facing messaging when throttling is active
+
 ## [0.3.1] - 2025-10-06
+
 ### Added
 - Now using batch compression for a reduction in separate compact.exe calls, resulting in a further 20-25% performance increase
 - Activating flags straight from the UI

--- a/README.md
+++ b/README.md
@@ -20,21 +20,7 @@
 ### Option 1: Using the Executable (Recommended)
 
 1. [Download the latest release](https://github.com/misha1350/trash-compactor/releases/latest)
-2. Open PowerShell as Administrator:
-    - Right-click Start Menu
-    - Select "Windows PowerShell (Admin)" or "Windows Terminal (Admin)"
-3. Drag the downloaded file into the PowerShell window, or navigate to the folder that contains the downloaded app:
-    ```powershell
-    cd path\to\downloads
-    ```
-4. Run the executable:
-    ```powershell
-    .\trash-compactor.exe
-    ```
-    Verbose output:
-    ```powershell
-    .\trash-compactor.exe -v
-    ```
+2. Run the executable file
 
 ### Option 2: Running from Source
 
@@ -54,6 +40,10 @@ Note: For Option 2, ensure Git and Python 3.8+ are installed on your system.
 Optional: you can compile the app yourself as I did, using PyInstaller:
     ```
     python -m PyInstaller --onefile --name trash-compactor --uac-admin main.py 
+    ```
+    or
+    ```
+    python -m PyInstaller --onefile --name trash-compactor --uac-admin main.py --upx-dir 'c:\path\to\upx-win64'
     ```
 
 ## Usage
@@ -127,8 +117,6 @@ To contribute to this project:
 ## To-Do
 
 ### Immediate Priorities (v0.2.x)
-- Properly display a warning message if the directory that is being compressed is on a spinning hard drive instead of an SSD, eMMC storage, or an SD card, because HDDs can suffer from fragmentation and compressing files and having them fragmented will drastically worsen the already bad hard drive performance in the OS
-  - Tell user to go buy an SSD and clone the hard drive or make a clean install of the system
 - Replace `compact.exe` calls with direct Windows API calls:
   - Use `FSCTL_SET_COMPRESSION` via `DeviceIoControl` for compression
   - Use `GetFileAttributes()` to check compression state

--- a/README.md
+++ b/README.md
@@ -116,41 +116,23 @@ To contribute to this project:
 
 ## To-Do
 
-### Immediate Priorities (v0.2.x)
-- Replace `compact.exe` calls with direct Windows API calls:
-  - Use `FSCTL_SET_COMPRESSION` via `DeviceIoControl` for compression
-  - Use `GetFileAttributes()` to check compression state
-  - Remove subprocess spawning overhead
-- Fix the stats logic (correct resulting folder size, counting files in regular output)
-
-### Short-term Goals (v0.3.0)
-- UI overhaul: 
-  - Create a progress bar (with .01% precision) at the bottom of the terminal window, tied to the amount of processed files relative to total files
-  - Put the silent output behind a feature flag (progress bar has to be enabled all the time)
-  - Close the terminal after finishing compression only after pressing "Q" once or "Esc" twice
-  - Count and display estimated time to completion based on average processing speed
-  - Keep the performance in mind by rendering UI updates on a separate thread
-- Improve system directory exclusion (with configurable rules)
-- Implement Chromium cache directory detection to avoid compressing already compressed cache files, in order to:
-  - Exclude `*\Cache\Cache_Data\` directory compression (of Chromium-based web browsers and Electron apps)
-  - Exclude Telegram's `\tdata\user_data\cache` and `\tdata\user_data\media_cache` compression
-  - Exclude Microsoft Teams' `\LocalCache\Microsoft\MSTeams\*` compression
-  - Exclude other most popular web browsers' cache directories compression
-  - Make these exclusions dynamic, not hard-coded - some entropy analysis might be required
-- Implement checking the compression status of the poorly compressed files in parallel (to make use of other cores)
-- Log this in the "info" channel to notify the user (me) about such files
+### Short-term Goals
+- Land a default exclusion map for Windows/system directories, emit skip reasons, and surface toggles for future overrides
+- Persist user overrides and low-yield directory notes to a lightweight JSON/INI profile so unattended runs inherit past decisions
+- Teach the scanner to tag well-known cache directories (Chromium/Electron/Telegram/Teams, etc.) via fast path-pattern heuristics before resorting to heavier analysis
+- Record poorly compressible hits in the info log to build a reusable "do not touch" ledger during normal runs
 - Add basic test suite for core functionality
-  - Implement a single-thread benchmark to check if the CPU is fast enough to use LZX compress (to check if the CPU is not an Intel Atom with its numerous, but weak cores)ion (to check if the CPU is not an Intel Atom with its numerous, but weak cores)
+  - Implement a single-thread benchmark to check if the CPU is fast enough to use LZX (to check if the CPU is not an Intel Atom with numerous, but weak cores)
   - Test compression detection accuracy
   - Verify that API calls work correctly
   - Check error handling paths
 
-### Long-term Goals (v0.x.x)
-- Create a 1-click/unattended mode of operation:
+### Long-term Goals
+- Create a 1-click/unattended mode of operation built on the recorded skip map:
   - Automatically discover large folders (replacing WizTree and having to manually scour through folders)
-  - Avoiding compressing specific folders, such as ones mentioned in short-term goals
+  - Avoid compressing specific folders, such as ones mentioned in short-term goals
   - Make life easier for The Greatest Technicians That Have Ever Lived
-- Implement smart compression detection:
+- Implement smart compression detection that can make decisions without touching the filesystem twice:
   - Use entropy analysis for compressibility estimation
   - Sample data chunks strategically
   - Cache results per file type

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from src import (
 )
 from src.console import display_banner, prompt_exit
 from src.launch import acquire_directory, interactive_configure
-from src.runtime import confirm_hdd_usage, configure_lzx, is_admin, is_windows_system_path
+from src.runtime import confirm_hdd_usage, configure_lzx, describe_protected_path, is_admin
 
 VERSION = "0.3.2"
 BUILD_DATE = "who cares"
@@ -198,9 +198,12 @@ def main() -> None:
     directory, args = acquire_directory(args, interactive_launch)
     args.directory = directory
 
-    # TODO: extend this guard to check nested Windows system directories, not just the root
-    if is_windows_system_path(directory):
-        logging.error("To compress Windows system files, please use 'compact.exe /compactos:always' instead")
+    # Guard against targeting protected system directories before proceeding with compression
+    protection_reason = describe_protected_path(directory)
+    if protection_reason:
+        logging.error("Cannot compress protected path: %s", protection_reason)
+        if 'Windows' in protection_reason:
+            logging.error("To compress Windows system files, use 'compact.exe /compactos:always' instead")
         prompt_exit()
         return
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
-from .compression import compress_directory, compress_directory_legacy
+from .compression import compress_directory, compress_directory_legacy, set_worker_cap
 from .stats import CompressionStats, print_compression_summary, Spinner, LegacyCompressionStats
 from .config import get_cpu_info
 from .timer import PerformanceMonitor, TimingStats

--- a/src/console.py
+++ b/src/console.py
@@ -13,7 +13,7 @@ BANNER = r"""
 
 
 class EscapeExit(Exception):
-    """Raised when the user exits via Esc twice."""
+    """Raised when the user exits by pressing Esc twice"""
 
 
 def announce_cancelled() -> None:

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -1,8 +1,9 @@
 import bisect
-import logging
 import ctypes
-import subprocess
+import logging
 import os
+import subprocess
+from dataclasses import dataclass
 from ctypes import wintypes
 from pathlib import Path
 from typing import Optional
@@ -13,6 +14,173 @@ from .config import MIN_COMPRESSIBLE_SIZE, SIZE_THRESHOLDS, SKIP_EXTENSIONS
 
 _SIZE_BREAKS, _SIZE_LABELS = zip(*SIZE_THRESHOLDS)
 KERNEL32 = ctypes.WinDLL('kernel32', use_last_error=True)
+
+DRIVE_UNKNOWN = 0
+DRIVE_NO_ROOT_DIR = 1
+DRIVE_REMOVABLE = 2
+DRIVE_FIXED = 3
+DRIVE_REMOTE = 4
+DRIVE_CDROM = 5
+DRIVE_RAMDISK = 6
+
+IOCTL_STORAGE_QUERY_PROPERTY = 0x2D1400
+PROPERTY_STANDARD_QUERY = 0
+STORAGE_DEVICE_SEEK_PENALTY_PROPERTY = 7
+
+GENERIC_READ = 0x80000000
+FILE_SHARE_READ = 0x00000001
+FILE_SHARE_WRITE = 0x00000002
+OPEN_EXISTING = 3
+FILE_ATTRIBUTE_NORMAL = 0x00000080
+INVALID_HANDLE_VALUE = wintypes.HANDLE(-1).value
+
+
+class STORAGE_PROPERTY_QUERY(ctypes.Structure):
+    _fields_ = [
+        ('PropertyId', ctypes.c_int),
+        ('QueryType', ctypes.c_int),
+        ('AdditionalParameters', ctypes.c_byte * 1),
+    ]
+
+
+class DEVICE_SEEK_PENALTY_DESCRIPTOR(ctypes.Structure):
+    _fields_ = [
+        ('Version', wintypes.DWORD),
+        ('Size', wintypes.DWORD),
+        ('IncursSeekPenalty', wintypes.BOOLEAN),
+    ]
+
+
+KERNEL32.GetDriveTypeW.argtypes = [wintypes.LPCWSTR]
+KERNEL32.GetDriveTypeW.restype = wintypes.UINT
+
+KERNEL32.GetVolumeInformationW.argtypes = [
+    wintypes.LPCWSTR,
+    wintypes.LPWSTR,
+    wintypes.DWORD,
+    ctypes.POINTER(wintypes.DWORD),
+    ctypes.POINTER(wintypes.DWORD),
+    ctypes.POINTER(wintypes.DWORD),
+    wintypes.LPWSTR,
+    wintypes.DWORD,
+]
+KERNEL32.GetVolumeInformationW.restype = wintypes.BOOL
+
+KERNEL32.CreateFileW.argtypes = [
+    wintypes.LPCWSTR,
+    wintypes.DWORD,
+    wintypes.DWORD,
+    ctypes.c_void_p,
+    wintypes.DWORD,
+    wintypes.DWORD,
+    wintypes.HANDLE,
+]
+KERNEL32.CreateFileW.restype = wintypes.HANDLE
+
+KERNEL32.DeviceIoControl.argtypes = [
+    wintypes.HANDLE,
+    wintypes.DWORD,
+    ctypes.c_void_p,
+    wintypes.DWORD,
+    ctypes.c_void_p,
+    wintypes.DWORD,
+    ctypes.POINTER(wintypes.DWORD),
+    ctypes.c_void_p,
+]
+KERNEL32.DeviceIoControl.restype = wintypes.BOOL
+
+KERNEL32.CloseHandle.argtypes = [wintypes.HANDLE]
+KERNEL32.CloseHandle.restype = wintypes.BOOL
+
+
+@dataclass(frozen=True)
+class VolumeDetails:
+    anchor: Optional[str]
+    drive_letter: Optional[str]
+    drive_type: int
+    filesystem: Optional[str]
+    rotational: Optional[bool]
+
+
+def _volume_anchor(path: str) -> Optional[str]:
+    if not path:
+        return None
+    drive, _ = os.path.splitdrive(path)
+    if not drive:
+        return None
+    drive = drive.rstrip('\\')
+    if not drive:
+        return None
+    return f"{drive}\\"
+
+
+def _filesystem_name(anchor: str) -> Optional[str]:
+    volume_name = ctypes.create_unicode_buffer(256)
+    fs_name = ctypes.create_unicode_buffer(256)
+    serial = wintypes.DWORD()
+    max_component = wintypes.DWORD()
+    flags = wintypes.DWORD()
+    if not KERNEL32.GetVolumeInformationW(
+        anchor,
+        volume_name,
+        len(volume_name),
+        ctypes.byref(serial),
+        ctypes.byref(max_component),
+        ctypes.byref(flags),
+        fs_name,
+        len(fs_name),
+    ):
+        error = ctypes.get_last_error()
+        if error:
+            logging.debug("GetVolumeInformationW failed for %s: %s", anchor, ctypes.WinError(error))
+        return None
+    name = fs_name.value.strip()
+    return name.upper() if name else None
+
+
+def _open_physical_drive(number: int) -> Optional[wintypes.HANDLE]:
+    device_path = f"\\\\.\\PhysicalDrive{number}"
+    handle = KERNEL32.CreateFileW(
+        device_path,
+        GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        None,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        None,
+    )
+    if handle == INVALID_HANDLE_VALUE:
+        error = ctypes.get_last_error()
+        if error:
+            logging.debug("CreateFileW failed for %s: %s", device_path, ctypes.WinError(error))
+        return None
+    return handle
+
+
+def get_volume_details(path: str) -> VolumeDetails:
+    anchor = _volume_anchor(path)
+    letter = _drive_letter(path)
+    if not anchor:
+        logging.debug("Unable to resolve volume anchor for %s", path)
+        return VolumeDetails(None, letter, DRIVE_UNKNOWN, None, None)
+
+    drive_type = KERNEL32.GetDriveTypeW(anchor)
+    filesystem = None
+    if drive_type not in {DRIVE_UNKNOWN, DRIVE_NO_ROOT_DIR}:
+        filesystem = _filesystem_name(anchor)
+
+    rotational = None
+    if drive_type == DRIVE_FIXED and letter and len(letter) == 2 and letter[1] == ':':
+        inspector = _DriveInspector(letter)
+        rotational = inspector.seek_penalty()
+        if rotational is None:
+            rotational = inspector.by_metadata()
+            if rotational is None:
+                rotational = inspector.by_latency()
+                if rotational is None:
+                    inspector.note_alignment()
+
+    return VolumeDetails(anchor, letter, drive_type, filesystem, rotational)
 
 
 def get_size_category(file_size: int) -> str:
@@ -98,27 +266,31 @@ def should_compress_file(file_path: Path, thorough_check: bool = False) -> tuple
 
 
 def is_hard_drive(drive_path: str) -> bool:
-    letter = _drive_letter(drive_path)
-    if not letter:
-        logging.debug("No drive letter found in %s", drive_path)
-        return False
-
     try:
-        inspector = _DriveInspector(letter)
-        verdict = inspector.by_metadata()
-        if verdict is not None:
-            return verdict
-
-        verdict = inspector.by_latency()
-        if verdict is not None:
-            return verdict
-
-        inspector.note_alignment()
-        logging.debug("Unable to definitively identify drive %s as HDD, assuming SSD/flash", letter)
-        return False
+        details = get_volume_details(drive_path)
     except Exception as exc:
         logging.error("Error detecting drive type: %s", exc)
         return False
+
+    if details.drive_type != DRIVE_FIXED:
+        logging.debug(
+            "Volume %s reports drive type %s; treating as non-HDD",
+            details.drive_letter or drive_path,
+            details.drive_type,
+        )
+        return False
+
+    if details.rotational is True:
+        return True
+
+    if details.rotational is False:
+        return False
+
+    logging.debug(
+        "Unable to definitively identify drive %s as HDD, assuming SSD/flash",
+        details.drive_letter or drive_path,
+    )
+    return False
 
 
 def _drive_letter(drive_path: str) -> Optional[str]:
@@ -134,9 +306,56 @@ class _DriveInspector:
     def __init__(self, drive_letter: str):
         self.drive_letter = drive_letter
         self.conn = wmi.WMI()
+        self._disk_number: Optional[int] = None
+
+    def seek_penalty(self) -> Optional[bool]:
+        disk_number = self._physical_disk_number()
+        if disk_number is None:
+            return None
+
+        handle = _open_physical_drive(disk_number)
+        if handle is None:
+            return None
+
+        try:
+            query = STORAGE_PROPERTY_QUERY()
+            query.PropertyId = STORAGE_DEVICE_SEEK_PENALTY_PROPERTY
+            query.QueryType = PROPERTY_STANDARD_QUERY
+
+            descriptor = DEVICE_SEEK_PENALTY_DESCRIPTOR()
+            returned = wintypes.DWORD()
+            # Some controllers (notably eMMC and SD bridges) decline this IOCTL, so it might fall back to softer signals
+            success = KERNEL32.DeviceIoControl(
+                handle,
+                IOCTL_STORAGE_QUERY_PROPERTY,
+                ctypes.byref(query),
+                ctypes.sizeof(query),
+                ctypes.byref(descriptor),
+                ctypes.sizeof(descriptor),
+                ctypes.byref(returned),
+                None,
+            )
+            if not success:
+                error = ctypes.get_last_error()
+                if error:
+                    logging.debug(
+                        "DeviceIoControl(query seek penalty) failed for %s: %s",
+                        self.drive_letter,
+                        ctypes.WinError(error),
+                    )
+                return None
+            return bool(descriptor.IncursSeekPenalty)
+        finally:
+            KERNEL32.CloseHandle(handle)
 
     def by_metadata(self) -> Optional[bool]:
-        for disk in self.conn.Win32_DiskDrive():
+        disk_number = self._physical_disk_number()
+        if disk_number is None:
+            return None
+
+        device_id = f"\\\\.\\PHYSICALDRIVE{disk_number}"
+        disks = self.conn.Win32_DiskDrive(DeviceID=device_id)
+        for disk in disks:
             logging.debug(
                 "Inspecting disk: %s",
                 {
@@ -147,12 +366,9 @@ class _DriveInspector:
                     'Model': getattr(disk, 'Model', 'N/A'),
                 },
             )
-            for partition in disk.associators("Win32_DiskDriveToDiskPartition"):
-                for logical_disk in partition.associators("Win32_LogicalDiskToPartition"):
-                    if logical_disk.DeviceID == self.drive_letter:
-                        verdict = self._metadata_verdict(disk)
-                        if verdict is not None:
-                            return verdict
+            verdict = self._metadata_verdict(disk)
+            if verdict is not None:
+                return verdict
         return None
 
     def _metadata_verdict(self, disk) -> Optional[bool]:
@@ -211,6 +427,9 @@ class _DriveInspector:
         return None
 
     def _physical_disk_number(self) -> Optional[int]:
+        if self._disk_number is not None:
+            return self._disk_number
+
         for relation in self.conn.Win32_LogicalDiskToPartition():
             try:
                 if relation.Dependent.DeviceID == self.drive_letter:
@@ -218,22 +437,29 @@ class _DriveInspector:
                     disk_id = antecedent.split('PHYSICALDRIVE')[1]
                     number = int(''.join(filter(str.isdigit, disk_id)))
                     logging.debug("Found physical disk number %s for drive %s", number, self.drive_letter)
+                    self._disk_number = number
                     return number
             except (AttributeError, IndexError, ValueError):
-                logging.debug("Failed to extract physical disk number from antecedent: %s", getattr(relation, 'Antecedent', 'N/A'))
+                logging.debug(
+                    "Failed to extract physical disk number from antecedent: %s",
+                    getattr(relation, 'Antecedent', 'N/A'),
+                )
         return None
 
     def note_alignment(self) -> None:
-        for disk in self.conn.Win32_DiskDrive():
-            for partition in disk.associators("Win32_DiskDriveToDiskPartition"):
-                for logical_disk in partition.associators("Win32_LogicalDiskToPartition"):
-                    if logical_disk.DeviceID == self.drive_letter:
-                        # Alignment is a weak signal, yet logging it helps post-mortem drive reports
-                        size = getattr(disk, 'Size', None)
-                        block = getattr(disk, 'DefaultBlockSize', None)
-                        logging.debug("Disk %s Size: %s, DefaultBlockSize: %s", getattr(disk, 'DeviceID', 'N/A'), size, block)
-                        try:
-                            if size and block and size % block == 0:
-                                logging.debug("Drive %s has aligned sectors, common in HDDs", self.drive_letter)
-                        except (TypeError, ZeroDivisionError):
-                            logging.debug("Error calculating sector alignment for drive %s", self.drive_letter)
+        disk_number = self._physical_disk_number()
+        if disk_number is None:
+            return
+
+        device_id = f"\\\\.\\PHYSICALDRIVE{disk_number}"
+        disks = self.conn.Win32_DiskDrive(DeviceID=device_id)
+        for disk in disks:
+            # Alignment is a weak signal, yet logging it helps post-mortem drive reports
+            size = getattr(disk, 'Size', None)
+            block = getattr(disk, 'DefaultBlockSize', None)
+            logging.debug("Disk %s Size: %s, DefaultBlockSize: %s", getattr(disk, 'DeviceID', 'N/A'), size, block)
+            try:
+                if size and block and size % block == 0:
+                    logging.debug("Drive %s has aligned sectors, common in HDDs", self.drive_letter)
+            except (TypeError, ZeroDivisionError):
+                logging.debug("Error calculating sector alignment for drive %s", self.drive_letter)

--- a/src/launch.py
+++ b/src/launch.py
@@ -14,6 +14,7 @@ FLAG_METADATA: dict[str, tuple[str, str]] = {
     'force_lzx': ('-f', 'Force LZX compression'),
     'thorough': ('-t', 'Thorough checking mode'),
     'brand_files': ('-b', 'Branding mode'),
+    'single_worker': ('-s', 'Throttle for HDDs'),
 }
 
 
@@ -25,6 +26,7 @@ class LaunchState:
     force_lzx: bool = False
     thorough: bool = False
     brand_files: bool = False
+    single_worker: bool = False
 
     def toggle(self, key: str) -> None:
         # Mutually exclusive switches get untangled here so the prompt never lies
@@ -66,7 +68,9 @@ def _apply_flag_string(raw: str, state: LaunchState) -> None:
         'force-lzx': 'force_lzx',
         'thorough': 'thorough',
         'brand-files': 'brand_files',
+        'single-worker': 'single_worker',
     }
+    short_map['s'] = 'single_worker'
 
     for token in tokens:
         if token.startswith('--'):
@@ -125,6 +129,7 @@ def interactive_configure(args: Namespace) -> Namespace:
         force_lzx=args.force_lzx,
         thorough=args.thorough,
         brand_files=args.brand_files,
+        single_worker=getattr(args, 'single_worker', False),
     )
 
     print(Fore.YELLOW + "\nInteractive launch detected. Configure your run before starting." + Style.RESET_ALL)
@@ -185,6 +190,7 @@ def interactive_configure(args: Namespace) -> Namespace:
     args.force_lzx = state.force_lzx
     args.thorough = state.thorough
     args.brand_files = state.brand_files
+    args.single_worker = state.single_worker
     return args
 
 

--- a/src/runtime.py
+++ b/src/runtime.py
@@ -6,7 +6,8 @@ from colorama import Fore, Style
 
 from . import config
 from .console import EscapeExit, announce_cancelled, read_user_input
-from .file_utils import is_hard_drive
+from .file_utils import DRIVE_FIXED, DRIVE_REMOTE, get_volume_details
+from .compression import set_worker_cap
 
 
 def sanitize_path(path: str) -> str:
@@ -73,16 +74,62 @@ def resolve_directory(argument: Optional[str]) -> str:
         pending = None
 
 
-def confirm_hdd_usage(directory: str) -> bool:
-    if not is_hard_drive(directory):
+def confirm_hdd_usage(directory: str, force_serial: bool) -> bool:
+    details = get_volume_details(directory)
+    throttle_requested = force_serial  # Carry over manual single-worker overrides
+    target_label = details.drive_letter or directory
+
+    if details.anchor is None:
+        logging.error("Unable to resolve volume for %s", directory)
+        print(Fore.RED + "Unable to resolve the target volume. Please verify the path." + Style.RESET_ALL)
+        return False
+
+    if details.drive_type == DRIVE_REMOTE:
+        logging.error("Network shares are not supported for compression targets: %s", directory)
+        print(Fore.RED + "Network shares are not supported targets for compression." + Style.RESET_ALL)
+        print("Please select a local NTFS volume instead.")
+        return False
+
+    if details.filesystem and details.filesystem != 'NTFS':
+        logging.error(
+            "Compression requires NTFS, but %s reports %s",
+            details.drive_letter or directory,
+            details.filesystem,
+        )
+        print(Fore.RED + "Windows compression requires NTFS." + Style.RESET_ALL)
+        print(f"Detected filesystem: {details.filesystem or 'unknown'}")
+        return False
+
+    if details.drive_type != DRIVE_FIXED:
+        logging.info(
+            "Volume %s is not a fixed disk (type=%s); skipping HDD warning.",
+            target_label,
+            details.drive_type,
+        )
+        if throttle_requested:
+            set_worker_cap(1)
+            logging.info("Single-worker mode honored even though the drive is not fixed media.")
         return True
 
-    print(Fore.YELLOW + "You may be attempting to compress files on a traditional spinning hard drive. (But the crude logic may be not working properly)")
-    print("If it truly is the case, this can lead to file fragmentation and decreased performance. (solid state storage doesn't have this)" + Style.RESET_ALL)
+    if details.rotational is not True:
+        if details.rotational is None:
+            logging.debug(
+                "Drive %s did not report seek penalty; treating as non-HDD."
+                " Flash controllers such as eMMC and SD readers may often omit this flag.",
+                target_label,
+            )
+        if throttle_requested:
+            set_worker_cap(1)
+            logging.info("Single-worker mode requested explicitly for %s.", target_label)
+        return True
+
+    print(Fore.YELLOW + "Detected a traditional spinning hard drive for this path." + Style.RESET_ALL)
+    print("Sustained compression can thrash the disk heads, fragment files, and slow app/game launches." + Style.RESET_ALL)
     print(Fore.YELLOW + "\nRecommendation:" + Style.RESET_ALL)
-    print("• Consider upgrading to an SSD for your system drive")
-    print("• If you must use an HDD, be aware that compression may reduce overall performance")
-    print("• Defragment your drive after compression completes")
+    print("• Run the task during idle hours and use the single-worker mode (-s)")
+    print("• Defragment the drive once compression finishes")
+    print("• Prefer compressing rarely modified folders on HDDs")
+
 
     print("\n" + Fore.YELLOW + "Do you want to proceed anyway? (y/n): " + Style.RESET_ALL, end="")
     try:
@@ -93,6 +140,21 @@ def confirm_hdd_usage(directory: str) -> bool:
     if response not in {"y", "yes"}:
         print(Fore.CYAN + "Operation cancelled." + Style.RESET_ALL)
         return False
+
+    if not throttle_requested:
+        print(Fore.YELLOW + "\nThrottle compression to a single worker to avoid disk fragmentation? (Y/n): " + Style.RESET_ALL, end="")
+        try:
+            throttle_response = read_user_input("").strip().lower()
+        except (KeyboardInterrupt, EscapeExit):
+            announce_cancelled()
+            return False
+        throttle_requested = throttle_response in {"", "y", "yes"}
+
+    if throttle_requested:
+        set_worker_cap(1)
+        logging.info("Single-worker mode engaged for %s due to HDD safeguards.", target_label)
+        if not force_serial:
+            print(Fore.YELLOW + "Running sequentially to keep fragmentation in check." + Style.RESET_ALL)
 
     print(Fore.YELLOW + "\nProceeding with compression on HDD. This may impact system performance." + Style.RESET_ALL)
     return True

--- a/src/runtime.py
+++ b/src/runtime.py
@@ -6,7 +6,13 @@ from colorama import Fore, Style
 
 from . import config
 from .console import EscapeExit, announce_cancelled, read_user_input
-from .file_utils import DRIVE_FIXED, DRIVE_REMOTE, get_volume_details
+from .file_utils import (
+    DRIVE_FIXED,
+    DRIVE_REMOTE,
+    get_protection_reason,
+    get_volume_details,
+    is_protected_path,
+)
 from .compression import set_worker_cap
 
 
@@ -24,7 +30,11 @@ def is_admin() -> bool:
 
 
 def is_windows_system_path(directory: str) -> bool:
-    return os.path.normpath(directory).lower().startswith(r"c:\windows")
+    return is_protected_path(directory)
+
+
+def describe_protected_path(directory: str) -> Optional[str]:
+    return get_protection_reason(directory)
 
 
 def configure_lzx(choice_enabled: bool, force_lzx: bool, cpu_capable: bool, physical: int, logical: int) -> bool:

--- a/src/timer.py
+++ b/src/timer.py
@@ -8,7 +8,6 @@ class TimingStats:
     total_time: float = 0.0
     file_scan_time: float = 0.0
     compression_time: float = 0.0
-    # Removed verification_time: float = 0.0
     total_files: int = 0
     files_compressed: int = 0
     files_skipped: int = 0
@@ -93,8 +92,6 @@ class PerformanceMonitor:
 
     def time_compression(self) -> "SectionTimer":
         return SectionTimer(self, 'compression_time')
-
-    # Removed time_verification
 
     def increment_file_count(self) -> None:
         self.stats.total_files += 1


### PR DESCRIPTION
## [0.3.2] - 2025-10-08
### Added
- `-s/--single-worker` flag to run compression sequentially for **better HDD support**
- HDD safeguard offers an opt-in prompt to downgrade to single-worker mode

### Changed
- Volume detection inspects only the target drive, blocks remote or non-NTFS paths up front, and logs flash controllers that omit seek-penalty hints
- Compression and branding worker pools respect the new runtime worker cap, with user-facing messaging when throttling is active